### PR TITLE
chore: freeze python packages except for bug fixes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-aiohttp
-aiosqlite
-discord.py
-python-dotenv
-validators
-pytz
-ruff
+aiohttp == 3.11.*
+aiosqlite == 0.21.*
+discord.py == 2.5.*
+python-dotenv == 1.1.*
+validators == 0.34.*
+pytz == 2025.2
+ruff == 0.11.*


### PR DESCRIPTION
so the packages don't change out from under us, and we can choose to upgrade packages on our own time by testing, modifying, then updating requirements.txt.