### PR TITLE
chore: fix precommit hook to lint and format only staged files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-# for staged files, lint, lint imports, and format.
-git diff -u --staged --name-only | tee \
->(ruff check --fix) \
->(ruff check --select I --fix) \
->(ruff format)
+stagedfiles=$(git diff -u --staged --name-only | grep ".py$") # get names of staged python files
+if [ -n "$stagedfiles" ]; then
+  # if variable is not empty, run lint and fomatting commands
+  # note: empty variable will cause commands to run on all files
+  ruff check --fix $stagedfiles             # lint
+  ruff check --select I --fix $stagedfiles  # lint imports (not included by default)
+  ruff format $stagedfiles                  # format
+fi


### PR DESCRIPTION
Previous version of the precommit hook wasn't working properly and was checking all files in the repository.